### PR TITLE
replace painter::draw() iterator argument by specs::RunArg

### DIFF
--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -64,6 +64,7 @@ impl pegasus::Init for Init {
     fn start(self, plan: &mut pegasus::Planner) -> () {
         plan.add_system(MoveSystem, "move", 20);
         let mut w = plan.mut_world();
+        w.register::<Drawable>();
         use std::f32::consts::PI;
         let num = 200;
         for i in 0 .. num {
@@ -84,13 +85,13 @@ struct Painter<R: gfx::Resources> {
 }
 
 impl<R: gfx::Resources> pegasus::Painter<R> for Painter<R> {
-    type Visual = Drawable;
-    fn draw<'a, I, C>(&mut self, iter: I, enc: &mut gfx::Encoder<R, C>) where
-        I: Iterator<Item = &'a Self::Visual>,
+    fn draw<'a, C>(&mut self, arg: specs::RunArg, enc: &mut gfx::Encoder<R, C>) where
         C: gfx::CommandBuffer<R>
     {
+        use specs::Join;
+        let visuals = arg.fetch(|w| w.read::<Drawable>());
         enc.clear(&self.data.out, [0.1, 0.2, 0.3, 1.0]);
-        for &Drawable(pos) in iter {
+        for &Drawable(pos) in visuals.iter() {
             self.data.pos = pos.into();
             enc.draw(&self.slice, &self.pso, &self.data);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,9 +39,7 @@ struct ChannelPair<R: gfx::Resources, C: gfx::CommandBuffer<R>> {
 }
 
 pub trait Painter<R: gfx::Resources>: 'static + Send {
-    type Visual: specs::Component;
-    fn draw<'a, I, C>(&mut self, I, &mut gfx::Encoder<R, C>) where
-            I: Iterator<Item = &'a Self::Visual>,
+    fn draw<'a, C>(&mut self, arg: specs::RunArg, &mut gfx::Encoder<R, C>) where
             C: gfx::CommandBuffer<R>;
 }
 
@@ -57,16 +55,13 @@ where
     P: Painter<R>,
 {
     fn run(&mut self, arg: specs::RunArg, _: Delta) {
-        use specs::Join;
         // get a new command buffer
         let mut encoder = match self.channel.receiver.recv() {
             Ok(r) => r,
             Err(_) => return,
         };
-        // fetch visuals
-        let vis = arg.fetch(|w| w.read::<P::Visual>());
         // render entities
-        self.painter.draw((&vis).iter(), &mut encoder);
+        self.painter.draw(arg, &mut encoder);
         // done
         let _ = self.channel.sender.send(encoder);
     }
@@ -113,8 +108,7 @@ impl<D: gfx::Device> Pegasus<D> {
                     sender: app_send,
                 },
             };
-            let mut w = specs::World::new();
-            w.register::<P::Visual>();
+            let w = specs::World::new();
             let mut plan = specs::Planner::new(w, 4);
             plan.add_system(draw_sys, DRAW_NAME, DRAW_PRIORITY);
             let shell = init.start(&mut plan);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub const DRAW_NAME: &'static str = "draw";
 pub trait Init: 'static {
     type Shell: 'static + Send;
     fn start(self, &mut Planner) -> Self::Shell;
-    fn proceed(_: &mut Self::Shell, _: &specs::World) -> bool { true }
+    fn proceed(_: &mut Self::Shell, _: &mut Planner, _: Delta) -> bool { true }
 }
 
 struct App<I: Init> {
@@ -28,8 +28,7 @@ impl<I: Init> App<I> {
         let elapsed = self.last_time.elapsed();
         self.last_time = time::Instant::now();
         let delta = elapsed.subsec_nanos() as f32 / 1e9 + elapsed.as_secs() as f32;
-        self.planner.dispatch(delta);
-        I::proceed(&mut self.shell, self.planner.mut_world())
+        I::proceed(&mut self.shell, &mut self.planner, delta)
     }
 }
 


### PR DESCRIPTION
by letting it fetch whatever it needs, it is now possible to have multiple visual component types or to use resources.

I had the issue in a toy project - I need multiple components to be able to draw (position, mesh and a couple of resources (shadercache, meshcache, ...). I think this gives back the flexibility of specs without adding any boilerplate you would not see in the rest of the project. What do you think ?